### PR TITLE
multiple values for keyword argument 'use_datetime'

### DIFF
--- a/dokuwiki.py
+++ b/dokuwiki.py
@@ -31,7 +31,7 @@ class DokuWiki(object):
     def __init__(self, url, user, password, **kwargs):
         """Initialize the object by connecting to the XMLRPC server."""
         # Initialize XMLRPC client.
-        use_datetime = kwargs.get('use_datetime', True)
+        use_datetime = kwargs.pop('use_datetime', True)
         url = '%s/lib/exe/xmlrpc.php?%s' % (
             url, urlencode({'u': user, 'p': password}))
         self.proxy = ServerProxy(url, use_datetime=use_datetime, **kwargs)


### PR DESCRIPTION
This should fix the "TypeError: ServerProxy constructor got multiple values for keyword argument 'use_datetime'" you get, if you provide use_datetime as a keyword argument to DokuWiki()