### PR TITLE
Fix typo in method description

### DIFF
--- a/dokuwiki.py
+++ b/dokuwiki.py
@@ -469,7 +469,7 @@ class Dataentry(object):
     @staticmethod
     def get(content, keep_order=False):
         """Get dataentry from *content*. *keep_order* indicates whether to
-        return an ordered dictionnay."""
+        return an ordered dictionary."""
         if keep_order:
             from collections import OrderedDict
             dataentry = OrderedDict()


### PR DESCRIPTION
"to return an ordered dictionnay" → "to return an ordered dictionary"